### PR TITLE
Add hamburger navigation menu

### DIFF
--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -6,7 +6,7 @@ $header_background_color: #fff;
   max-width: 48em;
   z-index: 3;
   background-color: $header_background_color;
-  min-height: 48px;
+  min-height: 64px;
 }
 
 .so-navigation__left {
@@ -21,6 +21,7 @@ $header_background_color: #fff;
   width: auto;
   height: 6em;
   position: absolute;
+  border: 0;
 }
 
 .so-navigation__about--no-logo {
@@ -60,7 +61,6 @@ $header_background_color: #fff;
   float: right;
   padding: 1em 2em;
   position: relative;
-  user-select: none;
 }
 
 .so-navigation__navicon {

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -175,10 +175,6 @@ li.so-navigation__menu-item--user > a {
     text-align: right;
   }
 
-  .so-header li {
-    float: left;
-  }
-
   .so-navigation__menu {
     clear: none;
     float: right;

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -135,6 +135,26 @@ $header_background_color: #fff;
   top: 0;
 }
 
+li.so-navigation__menu-item--user > a {
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.so-navigation__user-avatar {
+  max-height: 2.5em;
+  vertical-align: middle;
+  border: 0;
+}
+
+.so-navigation__user-name {
+  display: none;
+}
+
+.so-navigation__menu-item--logout {
+  width: 100%;
+  text-align: left;
+}
+
 @media all and (max-width: 48em) {
   .so-navigation {
     min-height: 48px;
@@ -142,6 +162,11 @@ $header_background_color: #fff;
 
   .so-navigation--logo {
     margin-right: 1em;
+  }
+
+  .so-navigation__user-name {
+    display: inline;
+    margin-left: 0.5em;
   }
 }
 

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -1,14 +1,19 @@
+$header_background_color: #fff;
+
 .so-navigation {
-  list-style: none;
-  margin-top: 0.2em;
-  vertical-align: top;
-  font-size: 0.9em;
-  margin-bottom: 0.3em;
-  padding-top: 0.5em;
+  position: static;
+  width: 100%;
+  max-width: 48em;
+  z-index: 3;
+  background-color: $header_background_color;
+  min-height: 48px;
 }
 
-.so-navigation-item {
-  vertical-align: top;
+.so-navigation__left {
+  display: block;
+  float: left;
+  margin-left: 1em;
+  margin-bottom: 0;
 }
 
 .so-navigation--logo {
@@ -16,10 +21,6 @@
   width: auto;
   height: 6em;
   position: absolute;
-}
-
-.so-navigation-item--image * img {
-  width: 2.5em;
 }
 
 .so-navigation--about--no-logo {
@@ -32,29 +33,113 @@
 .so-navigation--about {
   margin-left: 6em;
   margin-top: 0.5em;
-  margin-bottom: 3em;
   color: $deactive;
   font-size: 0.9em;
   display: inline-block;
 }
 
+.so-navigation__menu {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overflow: hidden;
+  background-color: $header_background_color;
+  font-size: 0.9em;
+  clear: both;
+  max-height: 0;
+}
+
+.so-navigation__menu li a {
+  display: block;
+  padding: 0.75em 1em;
+}
+
+.so-navigation__menu-icon {
+  cursor: pointer;
+  display: inline-block;
+  float: right;
+  padding: 1em 2em;
+  position: relative;
+  user-select: none;
+}
+
+.so-navigation__navicon {
+  background-color: $dark_background;
+  display: block;
+  height: 2px;
+  position: relative;
+  transition: background 0.2s ease-out;
+  width: 1em;
+}
+
+.so-navigation__navicon:before,
+.so-navigation__navicon:after {
+  background-color: $dark_background;
+  content: '';
+  display: block;
+  height: 100%;
+  position: absolute;
+  transition: all 0.2s ease-out;
+  width: 100%;
+}
+
+.so-navigation__navicon:before {
+  top: 5px;
+}
+
+.so-navigation__navicon:after {
+  top: -5px;
+}
+
+/* .so-navigation__menu-btn is a checkbox. according to its state we need to
+   change the displayed menu-icon and change the menu's visibility. */
+
+.so-navigation__menu-btn {
+  display: none;
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu {
+  max-height: 440px;
+  padding: 3em 0 1em;
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu--no-logo {
+  padding-top: 0;
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu li {
+  display: block;
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu li a:hover {
+  background-color: $light_background;
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu-icon .so-navigation__navicon {
+  background: transparent;
+  cursor: pointer;
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu-icon .so-navigation__navicon:before {
+  transform: rotate(-45deg);
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu-icon .so-navigation__navicon:after {
+  transform: rotate(45deg);
+}
+
+.so-navigation__menu-btn:checked ~ .so-navigation__menu-icon .so-navigation__navicon:before,
+.so-navigation__menu-btn:checked ~ .so-navigation__menu-icon .so-navigation__navicon:after {
+  top: 0;
+}
+
 @media all and (max-width: 48em) {
   .so-navigation {
-    text-align: left;
-    padding: 0.5em 0;
-  }
-
-  .so-navigation-item {
-    margin-bottom: 0.5em;
+    min-height: 48px;
   }
 
   .so-navigation--logo {
     margin-right: 1em;
-    margin-bottom: 3em;
-  }
-
-  .so-navigation--about {
-    margin-left: 5em;
   }
 }
 
@@ -63,15 +148,21 @@
     text-align: right;
   }
 
-  .so-navigation-item {
+  .so-header li {
+    float: left;
+  }
+
+  .so-navigation__menu {
+    clear: none;
+    float: right;
+    max-height: none;
+  }
+
+  .so-navigation__menu li {
     display: inline-block;
-    margin-left: 1em;
-    height: 2.5em;
   }
 
-  .so-navigation-item--image {
-    margin-top: -0.7em;
+  .so-navigation__menu-icon {
+    display: none;
   }
-
 }
-

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -163,6 +163,12 @@ li.so-navigation__menu-item--user > a {
     margin-right: 1em;
   }
 
+  .so-navigation__menu > li > a,
+  .so-navigation__menu > li > form {
+    display: block;
+    padding: 0.75em 0.3em;
+  }
+
   .so-navigation__user-name {
     display: inline;
     margin-left: 0.5em;

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -50,7 +50,8 @@ $header_background_color: #fff;
   max-height: 0;
 }
 
-.so-navigation__menu li a {
+.so-navigation__menu > li > a,
+.so-navigation__menu > li > form {
   display: block;
   padding: 0.75em 1em;
 }
@@ -111,7 +112,8 @@ $header_background_color: #fff;
   display: block;
 }
 
-.so-navigation__menu-btn:checked ~ .so-navigation__menu li a:hover {
+.so-navigation__menu-btn:checked ~ .so-navigation__menu li:hover,
+.so-navigation__menu-btn:checked ~ .so-navigation__menu li form:hover {
   background-color: $light_background;
 }
 

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -16,21 +16,21 @@ $header_background_color: #fff;
   margin-bottom: 0;
 }
 
-.so-navigation--logo {
+.so-navigation__logo {
   margin-top: -1.5em;
   width: auto;
   height: 6em;
   position: absolute;
 }
 
-.so-navigation--about--no-logo {
+.so-navigation__about--no-logo {
   margin-top: 0.5em;
   color: $deactive;
   font-size: 0.9em;
   display: inline-block;
 }
 
-.so-navigation--about {
+.so-navigation__about {
   margin-left: 6em;
   margin-top: 0.5em;
   color: $deactive;

--- a/web/static/css/objects/_navigation.css
+++ b/web/static/css/objects/_navigation.css
@@ -53,7 +53,7 @@ $header_background_color: #fff;
 .so-navigation__menu > li > a,
 .so-navigation__menu > li > form {
   display: block;
-  padding: 0.75em 1em;
+  padding: 0.2em 0.3em;
 }
 
 .so-navigation__menu-icon {
@@ -150,14 +150,13 @@ li.so-navigation__menu-item--user > a {
   display: none;
 }
 
-.so-navigation__menu-item--logout {
-  width: 100%;
-  text-align: left;
-}
-
 @media all and (max-width: 48em) {
   .so-navigation {
     min-height: 48px;
+  }
+
+  .so-navigation__left {
+    margin-left: 0;
   }
 
   .so-navigation--logo {
@@ -167,6 +166,16 @@ li.so-navigation__menu-item--user > a {
   .so-navigation__user-name {
     display: inline;
     margin-left: 0.5em;
+  }
+
+  .so-navigation__user-avatar {
+    max-height: 1.75em;
+  }
+
+  .so-navigation__menu-item--logout {
+    width: 100%;
+    text-align: left;
+    padding-left: 0.1em;
   }
 }
 

--- a/web/static/css/objects/_searchbar.css
+++ b/web/static/css/objects/_searchbar.css
@@ -54,6 +54,6 @@
 
 @media all and (min-width: 48em) {
   .so-searchbar {
-    margin: -1.3em -1em 1em -1em;
+    margin: -1.1em -1em 1em;
   }
 }

--- a/web/templates/layout/app.html.eex
+++ b/web/templates/layout/app.html.eex
@@ -15,7 +15,7 @@
 
     <div>
       <%= render SignDict.SharedView, "alerts.html", conn: @conn %>
-    <div>
+    </div>
 
     <div class="sc-main o-container o-container--medium">
       <main role="main">

--- a/web/templates/shared/navigation.html.eex
+++ b/web/templates/shared/navigation.html.eex
@@ -1,10 +1,10 @@
 <header class="so-navigation">
   <div class="so-navigation__left">
     <%= if assigns[:logo] == nil || assigns[:logo] == true do %>
-      <a href="/"><img src='/images/logo.svg' alt="<%= gettext("SignDict Logo") %>" class="so-navigation--logo"/></a>
-      <a href='/about' class='so-navigation--about'><%= gettext("About SignDict")%></a>
+      <a href="/"><img src='/images/logo.svg' alt="<%= gettext("SignDict Logo") %>" class="so-navigation__logo"/></a>
+      <a href='/about' class='so-navigation__about'><%= gettext("About SignDict")%></a>
     <% else %>
-      <a href='/about' class='so-navigation--about--no-logo'><%= gettext("About SignDict")%></a>
+      <a href='/about' class='so-navigation__about--no-logo'><%= gettext("About SignDict")%></a>
     <% end %>
   </div>
 

--- a/web/templates/shared/navigation.html.eex
+++ b/web/templates/shared/navigation.html.eex
@@ -29,7 +29,7 @@
 
         <li>
           <%= form_tag(session_path(@conn, :delete, @current_user), method: :delete) %>
-            <input type="submit" value="<%= gettext("Sign out") %>" class='sc-link so-nagvigation__menu-item--logout' />
+            <input type="submit" value="<%= gettext("Sign out") %>" class='sc-link so-navigation__menu-item--logout' />
           </form>
         </li>
 
@@ -40,8 +40,9 @@
           <a href="?locale=de" data-turbolinks="false">Deutsch</a>
         <% end %>
         </li>
-        <li>
-          <a href="<%= user_path(@conn, :show, @current_user) %>"><%= img_tag SignDict.User.avatar_url(@current_user), alt: gettext("The avatar image of this user") %></a>
+
+        <li class="so-navigation__menu-item--user">
+          <a href="<%= user_path(@conn, :show, @current_user) %>"><%= img_tag SignDict.User.avatar_url(@current_user), alt: gettext("The avatar image of this user"), class: "so-navigation__user-avatar" %><span class="so-navigation__user-name"><%= @current_user.name %></span></a>
         </li>
 
       <% else %>

--- a/web/templates/shared/navigation.html.eex
+++ b/web/templates/shared/navigation.html.eex
@@ -1,54 +1,66 @@
-<header>
-  <div class="o-grid o-grid--wrap">
-    <div class="o-grid__cell o-grid__cell--width-100 o-grid__cell--width-50@medium">
-      <%= if assigns[:logo] == nil || assigns[:logo] == true do %>
-        <a href="/"><img src='/images/logo.svg' alt="<%= gettext("SignDict Logo") %>" class="so-navigation--logo"/></a>
-        <a href='/about' class='so-navigation--about'><%= gettext("About SignDict")%></a>
-      <% else %>
-        <a href='/about' class='so-navigation--about--no-logo'><%= gettext("About SignDict")%></a>
-      <% end %>
-    </div>
-    <div class="o-grid__cell">
-      <nav role="navigation">
-        <ul class="so-navigation">
-          <%= if @current_user do %>
-            <%= if Canada.Can.can? @current_user, :show_backend, %{} do %>
-              <li class='so-navigation-item'>
-                <%= link "Admin", to: backend_dashboard_path(@conn, :index), data: [turbolinks: "false"] %>
-              </li>
-            <% end %>
-            <li class='so-navigation-item'>
-              <%= form_tag(session_path(@conn, :delete, @current_user), method: :delete) %>
-                <input type="submit" value="<%= gettext("Sign out") %>" class='sc-link' />
-              </form>
-            </li>
-            <li class='so-navigation-item'>
-              <%= if Gettext.get_locale(SignDict.Gettext) == "de" do %>
-                <a href="?locale=en" data-turbolinks="false">English</a>
-              <% else %>
-                <a href="?locale=de" data-turbolinks="false">Deutsch</a>
-              <% end %>
-            </li>
-            <li class='so-navigation-item so-navigation-item--image'>
-              <a href="<%= user_path(@conn, :show, @current_user) %>"><%= img_tag SignDict.User.avatar_url(@current_user), alt: gettext("The avatar image of this user") %></a>
-            </li>
-          <% else %>
-            <li class='so-navigation-item'>
-              <%= link gettext("Register"), to: user_path(@conn, :new) %>
-            </li>
-            <li class='so-navigation-item'>
-              <%= link gettext("Sign in"), to: session_path(@conn, :new) %>
-            </li>
-            <li class='so-navigation-item'>
-              <%= if Gettext.get_locale(SignDict.Gettext) == "de" do %>
-                <a href="?locale=en" data-turbolinks="false">English</a>
-              <% else %>
-                <a href="?locale=de" data-turbolinks="false">Deutsch</a>
-              <% end %>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
-    </div>
+<header class="so-navigation">
+  <div class="so-navigation__left">
+    <%= if assigns[:logo] == nil || assigns[:logo] == true do %>
+      <a href="/"><img src='/images/logo.svg' alt="<%= gettext("SignDict Logo") %>" class="so-navigation--logo"/></a>
+      <a href='/about' class='so-navigation--about'><%= gettext("About SignDict")%></a>
+    <% else %>
+      <a href='/about' class='so-navigation--about--no-logo'><%= gettext("About SignDict")%></a>
+    <% end %>
   </div>
+
+  <nav role="navigation">
+    <input class="so-navigation__menu-btn" hidden type="checkbox" id="so-navigation__menu-btn" />
+    <label class="so-navigation__menu-icon" for="so-navigation__menu-btn">
+      <span class="so-navigation__navicon"></span>
+    </label>
+
+    <%= if assigns[:logo] == nil || assigns[:logo] == true do %>
+      <ul class="so-navigation__menu">
+    <% else %>
+      <ul class="so-navigation__menu so-navigation__menu--no-logo">
+    <% end %>
+
+      <%= if @current_user do %>
+        <%= if Canada.Can.can? @current_user, :show_backend, %{} do %>
+          <li>
+            <%= link "Admin", to: backend_dashboard_path(@conn, :index), data: [turbolinks: "false"] %>
+          </li>
+        <% end %>
+
+        <li>
+          <%= form_tag(session_path(@conn, :delete, @current_user), method: :delete) %>
+            <input type="submit" value="<%= gettext("Sign out") %>" class='sc-link' />
+          </form>
+        </li>
+
+        <li>
+        <%= if Gettext.get_locale(SignDict.Gettext) == "de" do %>
+          <a href="?locale=en" data-turbolinks="false">English</a>
+        <% else %>
+          <a href="?locale=de" data-turbolinks="false">Deutsch</a>
+        <% end %>
+        </li>
+        <li>
+          <a href="<%= user_path(@conn, :show, @current_user) %>"><%= img_tag SignDict.User.avatar_url(@current_user), alt: gettext("The avatar image of this user") %></a>
+        </li>
+
+      <% else %>
+        <li>
+          <%= link gettext("Register"), to: user_path(@conn, :new) %>
+        </li>
+
+        <li>
+          <%= link gettext("Sign in"), to: session_path(@conn, :new) %>
+        </li>
+
+        <li>
+          <%= if Gettext.get_locale(SignDict.Gettext) == "de" do %>
+            <a href="?locale=en" data-turbolinks="false">English</a>
+          <% else %>
+            <a href="?locale=de" data-turbolinks="false">Deutsch</a>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  </nav>
 </header>

--- a/web/templates/shared/navigation.html.eex
+++ b/web/templates/shared/navigation.html.eex
@@ -29,7 +29,7 @@
 
         <li>
           <%= form_tag(session_path(@conn, :delete, @current_user), method: :delete) %>
-            <input type="submit" value="<%= gettext("Sign out") %>" class='sc-link' />
+            <input type="submit" value="<%= gettext("Sign out") %>" class='sc-link so-nagvigation__menu-item--logout' />
           </form>
         </li>
 


### PR DESCRIPTION
These changes introduce a hamburger menu.

It is build completely without JS by using a hidden checkbox. The checkbox' label allows the user to change the checked state. The label displays three horizontal lines aka 'hamburger menu'. The checkbox' state is then used to display or hide the menu by using the CSS pseudo selector `:checked`.

This implementation is not pixel perfect to the previous design. I suggest to give it a test drive and see if that's fine for you.

Tested on: Mac OS Safari 10.1.1, Firefox 54, IE10, Chrome 59, iOS 10.3 Safari 