### PR TITLE
Increase size of letter links on entry#index on small screens

### DIFF
--- a/web/static/css/app.css
+++ b/web/static/css/app.css
@@ -6,6 +6,7 @@
 @import "components/_forms.css";
 @import "components/_sidebar.css";
 @import "objects/_embed.css";
+@import "objects/_entry-index.css";
 @import "objects/_footer.css";
 @import "objects/_landing.css";
 @import "objects/_navigation.css";

--- a/web/static/css/base/_colors.css
+++ b/web/static/css/base/_colors.css
@@ -1,4 +1,3 @@
-$dark_background:  #10134B;
 $accent:           #3333AF;
 $highlight:        #50D8C8;
 $deactive:         #aeb0b0;
@@ -10,4 +9,6 @@ $alert_background: #FBECEB;
 $success:          #46B472;
 $success_background: #EEFBF3;
 
-$light_background: #f8f8fb;
+$light_background:  #f8f8fb;
+$dimmed_background: #e6e6e6;
+$dark_background:   #10134B;

--- a/web/static/css/objects/_entry-index.css
+++ b/web/static/css/objects/_entry-index.css
@@ -1,0 +1,47 @@
+$_letter_spacing_left: 0.35em;
+
+.so-entry-index__letter-links {
+  display: flex;
+  flex-wrap: wrap;
+
+  margin-left: -$_letter_spacing_left;
+  width: 100%;
+}
+
+.so-entry-index__letter-links > a {
+  white-space: nowrap;
+  margin-left: $_letter_spacing_left;
+}
+
+.so-entry-index__letter-links > a:after {
+  content: ' | ';
+  display: inline-block;
+  color: $dark_font;
+  margin-left: $_letter_spacing_left;
+}
+
+.so-entry-index__letter-links > a:last-child:after {
+  display: none;
+}
+
+@media all and (max-width: 48em) {
+  .so-entry-index__letter-links > a {
+    padding: 0.6em 0.15em;
+    margin-left: $_letter_spacing_left;
+    margin-top: 0.75em;
+
+    background-color: $light_background;
+    text-align: center;
+
+    width: 10%;
+    min-width: 2em;
+  }
+
+  .so-entry-index__letter-links > a:hover {
+    background-color: $dimmed_background;
+  }
+
+  .so-entry-index__letter-links > a:after {
+    display: none;
+  }
+}

--- a/web/templates/entry/index.html.eex
+++ b/web/templates/entry/index.html.eex
@@ -5,39 +5,39 @@
         <%= gettext("Browse through SignDict") %>
       </h1>
 
+      <div class="so-entry-index__letter-links">
+        <%= link "A", to: entry_path(@conn, :index, letter: "A") %>
+        <%= link "B", to: entry_path(@conn, :index, letter: "B") %>
+        <%= link "C", to: entry_path(@conn, :index, letter: "C") %>
+        <%= link "D", to: entry_path(@conn, :index, letter: "D") %>
+        <%= link "E", to: entry_path(@conn, :index, letter: "E") %>
+        <%= link "F", to: entry_path(@conn, :index, letter: "F") %>
+        <%= link "G", to: entry_path(@conn, :index, letter: "G") %>
+        <%= link "H", to: entry_path(@conn, :index, letter: "H") %>
+        <%= link "I", to: entry_path(@conn, :index, letter: "I") %>
+        <%= link "J", to: entry_path(@conn, :index, letter: "J") %>
+        <%= link "K", to: entry_path(@conn, :index, letter: "K") %>
+        <%= link "L", to: entry_path(@conn, :index, letter: "L") %>
+        <%= link "M", to: entry_path(@conn, :index, letter: "M") %>
+        <%= link "N", to: entry_path(@conn, :index, letter: "N") %>
+        <%= link "O", to: entry_path(@conn, :index, letter: "O") %>
+        <%= link "P", to: entry_path(@conn, :index, letter: "P") %>
+        <%= link "Q", to: entry_path(@conn, :index, letter: "Q") %>
+        <%= link "R", to: entry_path(@conn, :index, letter: "R") %>
+        <%= link "S", to: entry_path(@conn, :index, letter: "S") %>
+        <%= link "T", to: entry_path(@conn, :index, letter: "T") %>
+        <%= link "U", to: entry_path(@conn, :index, letter: "U") %>
+        <%= link "V", to: entry_path(@conn, :index, letter: "V") %>
+        <%= link "W", to: entry_path(@conn, :index, letter: "W") %>
+        <%= link "X", to: entry_path(@conn, :index, letter: "X") %>
+        <%= link "Y", to: entry_path(@conn, :index, letter: "Y") %>
+        <%= link "Z", to: entry_path(@conn, :index, letter: "Z") %>
+        <%= link "0-9", to: entry_path(@conn, :index, letter: "0-9") %>
+      </div>
+
       <p>
         <%= raw gettext("Feeling adventurous? Try <a href='%{random}'>a random entry</a>.", random: feeling_lucky_path(@conn, :index)) %>
       </p>
-
-      <div>
-        <%= link "A", to: entry_path(@conn, :index, letter: "A") %> |
-        <%= link "B", to: entry_path(@conn, :index, letter: "B") %> |
-        <%= link "C", to: entry_path(@conn, :index, letter: "C") %> |
-        <%= link "D", to: entry_path(@conn, :index, letter: "D") %> |
-        <%= link "E", to: entry_path(@conn, :index, letter: "E") %> |
-        <%= link "F", to: entry_path(@conn, :index, letter: "F") %> |
-        <%= link "G", to: entry_path(@conn, :index, letter: "G") %> |
-        <%= link "H", to: entry_path(@conn, :index, letter: "H") %> |
-        <%= link "I", to: entry_path(@conn, :index, letter: "I") %> |
-        <%= link "J", to: entry_path(@conn, :index, letter: "J") %> |
-        <%= link "K", to: entry_path(@conn, :index, letter: "K") %> |
-        <%= link "L", to: entry_path(@conn, :index, letter: "L") %> |
-        <%= link "M", to: entry_path(@conn, :index, letter: "M") %> |
-        <%= link "N", to: entry_path(@conn, :index, letter: "N") %> |
-        <%= link "O", to: entry_path(@conn, :index, letter: "O") %> |
-        <%= link "P", to: entry_path(@conn, :index, letter: "P") %> |
-        <%= link "Q", to: entry_path(@conn, :index, letter: "Q") %> |
-        <%= link "R", to: entry_path(@conn, :index, letter: "R") %> |
-        <%= link "S", to: entry_path(@conn, :index, letter: "S") %> |
-        <%= link "T", to: entry_path(@conn, :index, letter: "T") %> |
-        <%= link "U", to: entry_path(@conn, :index, letter: "U") %> |
-        <%= link "V", to: entry_path(@conn, :index, letter: "V") %> |
-        <%= link "W", to: entry_path(@conn, :index, letter: "W") %> |
-        <%= link "X", to: entry_path(@conn, :index, letter: "X") %> |
-        <%= link "Y", to: entry_path(@conn, :index, letter: "Y") %> |
-        <%= link "Z", to: entry_path(@conn, :index, letter: "Z") %> |
-        <%= link "0-9", to: entry_path(@conn, :index, letter: "0-9") %>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The links to each letter were very hard to tap on small screens. Browsing the heart of SignDict, the entries, was difficult on such screens.

This PR increases the tap-able size of each letter on small screens. 

![screen shot 2017-07-06 at 11 44 49](https://user-images.githubusercontent.com/350021/27905550-8a95dccc-6240-11e7-9523-38fe3e8276f5.png)
