### PR TITLE
Recheck videos after 10 minutes

### DIFF
--- a/lib/sign_dict/worker/recheck_video.ex
+++ b/lib/sign_dict/worker/recheck_video.ex
@@ -1,0 +1,31 @@
+defmodule SignDict.Worker.RecheckVideo do
+  @moduledoc """
+  Sadly JWPlayer does not have a status that
+  shows us that all video qualities have been
+  transcoded. It just returns a "ready" status
+  as soon as one quality is available. This
+  Worker will recheck the status and updates
+  the video with all currently available files.
+  It is triggered in the SignDict.Worker.CheckVideoStatus
+  10 minutes after the ready event was fired.
+  This gives JWPlayer enough time to finish
+  everything.
+  """
+  require Bugsnex
+
+  alias SignDict.Repo
+  alias SignDict.Video
+
+  @process_sleep_time 100
+
+  def perform(video_id, video_service \\ SignDict.Transcoder.JwPlayer,
+              sleep_ms \\ @process_sleep_time) do
+    Bugsnex.handle_errors %{video_id: video_id} do
+      # Rate limit the workers, sadly i didn't find a better way :(
+      Process.sleep(sleep_ms)
+
+      video = Repo.get(Video, video_id)
+      video_service.check_status(video)
+    end
+  end
+end

--- a/test/lib/worker/check_video_status_test.exs
+++ b/test/lib/worker/check_video_status_test.exs
@@ -49,6 +49,7 @@ defmodule SignDict.Worker.CheckVideoStatusTest do
       assert Repo.get(Video, video_id).state == "transcoding"
       assert_received {:check_status, ^video_id}
       assert_received {:enqueue_in, 60, SignDict.Worker.CheckVideoStatus, [^video_id]}
+      refute_received {:enqueue_in, 60 * 10, SignDict.Worker.RecheckVideo, [^video_id]}
     end
 
     test "it publishes the video if it is done" do
@@ -57,6 +58,7 @@ defmodule SignDict.Worker.CheckVideoStatusTest do
       assert Repo.get(Video, video_id).state == "waiting_for_review"
       assert_received {:check_status, ^video_id}
       refute_received {:enqueue_in, 60, SignDict.Worker.CheckVideoStatus, [^video_id]}
+      assert_received {:enqueue_in, 60 * 10, SignDict.Worker.RecheckVideo, [^video_id]}
     end
 
     test "it sends an email and notifies the users" do

--- a/test/lib/worker/recheck_video_test.exs
+++ b/test/lib/worker/recheck_video_test.exs
@@ -1,0 +1,25 @@
+defmodule SignDict.Worker.RecheckVideoTest do
+  use SignDict.ModelCase
+
+  import SignDict.Factory
+
+  alias SignDict.Worker.RecheckVideo
+
+  defmodule VideoServiceMockDone do
+    @behaviour SignDict.Transcoder.API
+    def upload_video(_video), do: :sent
+    def check_status(video) do
+      send self(), {:check_status, video.id}
+      :done
+    end
+  end
+
+  describe "perform/2" do
+    test "it publishes the video if it is done" do
+      video_id = insert(:video_with_entry, %{state: "transcoding"}).id
+      assert RecheckVideo.perform(video_id, VideoServiceMockDone, 0) == :done
+      assert_received {:check_status, ^video_id}
+    end
+  end
+
+end


### PR DESCRIPTION
Sadly JWPlayer has no „all transcodings done“ status. Our workaround for now is to check the videos again after 10 minutes

closes #200 