### PR TITLE
English fixes

### DIFF
--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -511,10 +511,6 @@ msgstr "Logo zweitag"
 msgid "Newsletter sign up"
 msgstr "Anmeldung zum Newsletter"
 
-#: web/templates/page/index.html.eex:53
-msgid "Our mission: to help understanding each other."
-msgstr "Einander gemeinsam verstehen: Das ist unsere Mission."
-
 #: web/controllers/search_controller.ex:13 web/templates/page/index.html.eex:34
 #: web/templates/shared/searchbar.html.eex:10
 msgid "Search"
@@ -984,7 +980,7 @@ msgid "You think an entry is missing? Feel free do add it here. After entering t
 msgstr "Du denkst ein Eintrag fehlt? Dann trage diesen gerne hier ein. Nachdem du den Text eingegeben hast, wirst du im nächsten Schritt die Möglichkeit haben, die Gebärde aufzunehmen."
 
 #: web/templates/search/index.html.eex:44
-msgid "Missing an entry? Do you know how to sign it? Than please add it with the help of your webcam."
+msgid "Missing an entry? Do you know how to sign it? Then please add it with the help of your webcam."
 msgstr "Fehlt ein Eintrag? Weißt du, wie dieser gebärdet wird? Dann füge diesen Bitte mit Hilfe deiner Webcam hinzu."
 
 #: web/controllers/entry_controller.ex:23
@@ -1007,10 +1003,6 @@ msgstr "Leider konnte ich den Eintrag nicht finden, zudem du eine Gebärde aufne
 #: web/templates/page/welcome.html.eex:16
 msgid "Add a new sign >"
 msgstr "Eine neue Gebärde hinzufügen >"
-
-#: web/templates/page/index.html.eex:16
-msgid "Currenty %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>"
-msgstr "Aktuell haben %{humans} Menschen <a href=\"%{link}\">%{signs} Gebärden</a> beigetragen"
 
 #: web/email.ex:68
 msgid "Your video was approved :)"
@@ -1072,3 +1064,13 @@ msgstr "Leider brauchst du einen aktuellen Chrome Browser für die Aufnahmefunkt
 #: web/templates/backend/user/index.html.eex:6
 msgid "user.id"
 msgstr "ID"
+
+#, fuzzy
+#: web/templates/page/index.html.eex:53
+msgid "Our mission: to help in understanding each other."
+msgstr "Einander gemeinsam verstehen: Das ist unsere Mission."
+
+#, fuzzy
+#: web/templates/page/index.html.eex:16
+msgid "So far %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>"
+msgstr "Aktuell haben %{humans} Menschen <a href=\"%{link}\">%{signs} Gebärden</a> beigetragen"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -511,10 +511,6 @@ msgstr ""
 msgid "Newsletter sign up"
 msgstr ""
 
-#: web/templates/page/index.html.eex:53
-msgid "Our mission: to help understanding each other."
-msgstr ""
-
 #: web/controllers/search_controller.ex:13 web/templates/page/index.html.eex:34
 #: web/templates/shared/searchbar.html.eex:10
 msgid "Search"
@@ -984,7 +980,7 @@ msgid "You think an entry is missing? Feel free do add it here. After entering t
 msgstr ""
 
 #: web/templates/search/index.html.eex:44
-msgid "Missing an entry? Do you know how to sign it? Than please add it with the help of your webcam."
+msgid "Missing an entry? Do you know how to sign it? Then please add it with the help of your webcam."
 msgstr ""
 
 #: web/controllers/entry_controller.ex:23
@@ -1006,10 +1002,6 @@ msgstr ""
 
 #: web/templates/page/welcome.html.eex:16
 msgid "Add a new sign >"
-msgstr ""
-
-#: web/templates/page/index.html.eex:16
-msgid "Currenty %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>"
 msgstr ""
 
 #: web/email.ex:68
@@ -1071,4 +1063,12 @@ msgstr ""
 
 #: web/templates/backend/user/index.html.eex:6
 msgid "user.id"
+msgstr ""
+
+#: web/templates/page/index.html.eex:53
+msgid "Our mission: to help in understanding each other."
+msgstr ""
+
+#: web/templates/page/index.html.eex:16
+msgid "So far %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -511,10 +511,6 @@ msgstr ""
 msgid "Newsletter sign up"
 msgstr ""
 
-#: web/templates/page/index.html.eex:53
-msgid "Our mission: to help understanding each other."
-msgstr ""
-
 #: web/controllers/search_controller.ex:13 web/templates/page/index.html.eex:34
 #: web/templates/shared/searchbar.html.eex:10
 msgid "Search"
@@ -522,7 +518,7 @@ msgstr ""
 
 #: web/templates/page/index.html.eex:50
 msgid "SignDict believes..."
-msgstr "SignDict believes that communication is the key to an open society. To increase the integration of deaf we created a dictionary where everyone can participate in."
+msgstr "SignDict believes that communication is the key to an open society. To increase the integration of deaf communities, we created a living dictionary and invite everyone to participate."
 
 #: web/templates/shared/footer.html.eex:27
 msgid "SignDict is a sign language dictionary where everyone can participate"
@@ -984,7 +980,7 @@ msgid "You think an entry is missing? Feel free do add it here. After entering t
 msgstr ""
 
 #: web/templates/search/index.html.eex:44
-msgid "Missing an entry? Do you know how to sign it? Than please add it with the help of your webcam."
+msgid "Missing an entry? Do you know how to sign it? Then please add it with the help of your webcam."
 msgstr ""
 
 #: web/controllers/entry_controller.ex:23
@@ -1006,10 +1002,6 @@ msgstr ""
 
 #: web/templates/page/welcome.html.eex:16
 msgid "Add a new sign >"
-msgstr ""
-
-#: web/templates/page/index.html.eex:16
-msgid "Currenty %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>"
 msgstr ""
 
 #: web/email.ex:68
@@ -1072,3 +1064,13 @@ msgstr ""
 #: web/templates/backend/user/index.html.eex:6
 msgid "user.id"
 msgstr "ID"
+
+#, fuzzy
+#: web/templates/page/index.html.eex:53
+msgid "Our mission: to help in understanding each other."
+msgstr ""
+
+#, fuzzy
+#: web/templates/page/index.html.eex:16
+msgid "So far %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>"
+msgstr ""

--- a/web/templates/page/about_en.html.eex
+++ b/web/templates/page/about_en.html.eex
@@ -3,37 +3,37 @@
     <h1>What is SignDict?</h1>
     <p>
       This project is an open sign language dictionary.
-      A sign missing, or you know another sign for the word? Record and add it with one click.
+      Is there a sign missing, or do you know another sign for the word? Record and add it with one click.
       The only thing you need for this is your own webcam.
     </p>
     <p>
       This project is funded by the <a href="https://prototypefund.de">Prototype Fund</a>.
-      Start of development was the 1st of March 2017.
+      Development started on March 1, 2017.
     </p>
     <h1>Who is the target audience?</h1>
     <p>
       This dictionary is aimed at people already fluent and to learners.
-      It will be a dictionary and learning aid and wants to raise the
-      awareness of sign language in the public space.
+      It will be a dictionary and learning aid and will raise
+      awareness of sign language in public spaces.
     </p>
     <h1>Why do we need this?</h1>
     <p>
       The goal is to create the first interactive sign language dictionary in which
-      everyone can participate in without any technical knowledge.
+      everyone can participate without the need for technical knowledge.
     </p>
     <p>
       If you search for online sign language dictionaries, you will find a few.
-      Sadly most have a few hundred words and don’t allow to add new signs.
-      Additionally only a few show more than one sign for a word.
+      Sadly, most of them only have a few hundred words and don’t allow users to add new signs.
+      Additionally, only a few show more than one sign per word.
       I want to try to have as many sign variations for a word as possible.
     </p>
     <p>
-      This lead to the idea to crowdsource the dictionary. Everyone can participate and add a sign.
-      Most computers nowadays have a webcam with a quality that is sufficient to record sign language.
-      Together we as the sign language community can build an interactive dictionary. One that has as many signs as possible.
-      At the beginning the dictionary will only have the german sign language (DGS), but we will add more languages as we grow.
+      This led to the idea of crowdsourcing the dictionary. Everyone can participate and add a sign.
+      Most computers nowadays have a webcam with a high enough quality that is sufficient to record sign language.
+      Together, we as the sign language community can build an interactive dictionary, one that has as many signs as possible.
+      In the beginning the dictionary will only be equipped for German sign language (DGS), but we will add more languages as we grow.
     </p>
-    <h1>Why do you build this?</h1>
+    <h1>Why are you building this?</h1>
     <p>
       <img class="o-image" src="/images/bodo.jpg" alt="Bodo"/>
       <br/>
@@ -43,10 +43,10 @@
     </p>
     <p>
       I am a <a href="https://en.wikipedia.org/wiki/Child_of_deaf_adult">CODA</a>, a child of deaf adults.
-      Since I started to see videos appear online, I was dreaming of a service like this.
+      From the moment I first saw an online video, I started dreaming of a service like this one.
       In 2013 I wrote a <a href="http://bitboxer.de/2013/10/25/see-me-speak/">proof of concept</a> with a few friends during a hackathon.
-      One of the learnings back then was that the web technology was not good enough at that time to do it as good as I wanted.
-      Luckily those problems are solved now and I can start building it.
+      One of the learnings back then was that the web technology was not yet good enough to build the type of application that I wanted.
+      Luckily, those problems have since been solved and I can start building SignDict.
     </p>
     <h1>OpenSource</h1>
     <p>
@@ -58,7 +58,7 @@
       Thanks to the <a href="http://prototypefund.de/en/">Prototype Fund</a>,
       the <a href="https://www.bmbf.de/">Federal Ministry of Education and Research</a> (BMBF)
       and their <a href="https://prototypefund.de/2016/10/25/1022/">jury</a>
-      for selecting this project as a finalist of the 1st round of the Prototype Fund.
+      for selecting this project as a finalist in the 1st round of the Prototype Fund.
     </p>
   </div>
 </div>

--- a/web/templates/page/index.html.eex
+++ b/web/templates/page/index.html.eex
@@ -13,7 +13,7 @@
             <%= {:safe, gettext("SignDict is an open dictionary for sign language. <strong>Everyone is invited to join in.</strong>")} %>
           </p>
           <p class='so-landing--banner--stats'>
-            <%= raw(gettext("Currenty %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>",
+            <%= raw(gettext("So far %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>",
                   humans: @human_count, signs: @sign_count,
                   link: entry_path(@conn, :index)
              )) %>
@@ -50,7 +50,7 @@
           <%= text_to_html(gettext("SignDict believes...")) %>
           <p>
             <strong>
-              <%= gettext("Our mission: to help understanding each other.") %>
+              <%= gettext("Our mission: to help in understanding each other.") %>
             </strong>
           </p>
         </div>

--- a/web/templates/search/index.html.eex
+++ b/web/templates/search/index.html.eex
@@ -41,7 +41,7 @@
 <div class="o-grid o-grid--wrap">
   <div class="o-grid__cell">
     <p>
-      <%= gettext("Missing an entry? Do you know how to sign it? Than please add it with the help of your webcam.") %>
+      <%= gettext("Missing an entry? Do you know how to sign it? Then please add it with the help of your webcam.") %>
     </p>
     <p>
       <%= link gettext("Add new entry"), to: entry_path(@conn, :new), class: "sc-button sc-button--small" %>


### PR DESCRIPTION
Hello again! :wave: 

This PR is just changing some of the text on the website. I hope I handled the `.po` & `.pot` files correctly, I had to manually fix the `.pot` files a bit as I rebased master. Let me know if something looks strange. 

Some questions:
1. I changed "Our mission: to help understanding each other" to "Our mission: to help in understanding each other.". However, "Our mission: to help understand each other" also works and perhaps rolls off the tongue a bit nicer, but I think the sentence I chose strikes more at the idea of understanding each other in many ways, not just through language. 
2. `#fuzzy` was added to the top of some of my new translation strings (I assume when running `mix gettext.extract --merge`). Should I remove that? And do you know why that was added?

woot woot! :smile: 