### PR TITLE
Use search queries as default text when creating new entry

### DIFF
--- a/lib/sign_dict_web/controllers/entry_controller.ex
+++ b/lib/sign_dict_web/controllers/entry_controller.ex
@@ -73,7 +73,7 @@ defmodule SignDictWeb.EntryController do
 
       {:error, changeset} ->
         languages = Repo.all(Language)
-        render(conn, "new.html", changeset: changeset, languages: languages)
+        render(conn, "new.html", changeset: changeset, languages: languages, text: conn.params["text"])
     end
   end
 

--- a/lib/sign_dict_web/controllers/entry_controller.ex
+++ b/lib/sign_dict_web/controllers/entry_controller.ex
@@ -51,7 +51,7 @@ defmodule SignDictWeb.EntryController do
   def new(conn, _params) do
     changeset = Entry.changeset(%Entry{})
     languages = Repo.all(Language)
-    render(conn, "new.html", changeset: changeset, languages: languages, text: conn.params["text"])
+    render(conn, "new.html", changeset: changeset, languages: languages, text: _params["text"])
   end
 
   def create(conn, %{"entry" => entry_params}) do

--- a/lib/sign_dict_web/controllers/entry_controller.ex
+++ b/lib/sign_dict_web/controllers/entry_controller.ex
@@ -51,7 +51,7 @@ defmodule SignDictWeb.EntryController do
   def new(conn, _params) do
     changeset = Entry.changeset(%Entry{})
     languages = Repo.all(Language)
-    render(conn, "new.html", changeset: changeset, languages: languages)
+    render(conn, "new.html", changeset: changeset, languages: languages, text: conn.params["text"])
   end
 
   def create(conn, %{"entry" => entry_params}) do

--- a/lib/sign_dict_web/controllers/entry_controller.ex
+++ b/lib/sign_dict_web/controllers/entry_controller.ex
@@ -48,10 +48,10 @@ defmodule SignDictWeb.EntryController do
     |> render_entry
   end
 
-  def new(conn, _params) do
+  def new(conn, params) do
     changeset = Entry.changeset(%Entry{})
     languages = Repo.all(Language)
-    render(conn, "new.html", changeset: changeset, languages: languages, text: _params["text"])
+    render(conn, "new.html", changeset: changeset, languages: languages, text: params["text"])
   end
 
   def create(conn, %{"entry" => entry_params}) do

--- a/lib/sign_dict_web/templates/entry/form.html.eex
+++ b/lib/sign_dict_web/templates/entry/form.html.eex
@@ -7,7 +7,7 @@
 
   <div class="o-form-element">
     <%= label f, :text, gettext("entry.text"), class: "c-label" %>
-    <%= text_input f, :text, class: "c-field #{class_for_error(f, :text)}" %>
+    <%= text_input f, :text, value: "#{@text}", class: "c-field #{class_for_error(f, :text)}" %>
     <%= error_tag f, :text %>
   </div>
 

--- a/lib/sign_dict_web/templates/entry/form.html.eex
+++ b/lib/sign_dict_web/templates/entry/form.html.eex
@@ -7,7 +7,7 @@
 
   <div class="o-form-element">
     <%= label f, :text, gettext("entry.text"), class: "c-label" %>
-    <%= text_input f, :text, value: "#{@text}", class: "c-field #{class_for_error(f, :text)}" %>
+    <%= text_input f, :text, value: @text, class: "c-field #{class_for_error(f, :text)}" %>
     <%= error_tag f, :text %>
   </div>
 

--- a/lib/sign_dict_web/templates/entry/new.html.eex
+++ b/lib/sign_dict_web/templates/entry/new.html.eex
@@ -6,4 +6,5 @@
 
 <%= render "form.html", changeset: @changeset,
                         languages: @languages,
+                        text: @text,
                         action: entry_path(@conn, :create) %>

--- a/lib/sign_dict_web/templates/search/index.html.eex
+++ b/lib/sign_dict_web/templates/search/index.html.eex
@@ -44,7 +44,7 @@
       <%= gettext("Missing an entry? Do you know how to sign it? Then please add it with the help of your webcam.") %>
     </p>
     <p>
-      <%= link gettext("Add new entry"), to: entry_path(@conn, :new), class: "sc-button sc-button--small" %>
+      <%= link gettext("Add new entry"), to: entry_path(@conn, :new, text: @conn.params["q"]), class: "sc-button sc-button--small" %>
     </p>
   </div>
 </div>


### PR DESCRIPTION
When creating a new entry from the search result page, use the search term as default text for the new entry.