### PR TITLE
Actually count the number of contributors

### DIFF
--- a/lib/sign_dict_web/controllers/page_controller.ex
+++ b/lib/sign_dict_web/controllers/page_controller.ex
@@ -2,9 +2,8 @@ defmodule SignDictWeb.PageController do
   use SignDictWeb, :controller
 
   def index(conn, _params) do
-    human_count = Repo.aggregate(SignDict.User, :count, :id)
     render conn, "index.html", layout: {SignDictWeb.LayoutView, "empty.html"},
-      human_count: human_count, sign_count: sign_count()
+      contributor_count: contributor_count(), sign_count: sign_count()
   end
 
   def imprint(conn, _params) do
@@ -45,5 +44,13 @@ defmodule SignDictWeb.PageController do
     SignDict.Video
     |> where(state: "published")
     |> Repo.aggregate(:count, :id)
+  end
+
+  defp contributor_count do
+    SignDict.Video
+    |> where(state: "published")
+    |> select([v], v.user_id)
+    |> distinct(true)
+    |> Repo.aggregate(:count, :user_id)
   end
 end

--- a/lib/sign_dict_web/templates/page/index.html.eex
+++ b/lib/sign_dict_web/templates/page/index.html.eex
@@ -14,7 +14,7 @@
           </p>
           <p class='so-landing--banner--stats'>
             <%= raw(gettext("So far %{humans} humans have added <a href=\"%{link}\">%{signs} signs</a>",
-                  humans: @human_count, signs: @sign_count,
+                  humans: @contributor_count, signs: @sign_count,
                   link: entry_path(@conn, :index)
              )) %>
           </p>


### PR DESCRIPTION
Currently, the homepage displays the number of all registered users, but the text says it displays the number of people who have uploaded a video.