### PR TITLE
Show recent video uploads instead of recently updated entries

### DIFF
--- a/lib/sign_dict_web/controllers/entry_controller.ex
+++ b/lib/sign_dict_web/controllers/entry_controller.ex
@@ -8,6 +8,7 @@ defmodule SignDictWeb.EntryController do
   alias SignDict.List
   alias SignDict.Services.EntryVideoLoader
   alias SignDict.Services.OpenGraph
+  alias SignDict.Video
   alias SignDictWeb.Router.Helpers
 
   def index(conn, params) do
@@ -29,17 +30,18 @@ defmodule SignDictWeb.EntryController do
   end
   
   def latest(conn, params) do
-    entries =
-      Entry.active_entries()
-      |> Entry.with_current_video()
-      |> order_by(desc: :updated_at)
-      |> Repo.paginate(params)
+    query = from v in Video,
+      where: v.state == ^"published",
+      join: e in assoc(v, :entry),
+      order_by: [desc: v.inserted_at],
+      preload: :entry
+    videos = Repo.paginate(query, params)
 
     render(conn, "latest.html",
       layout: {SignDictWeb.LayoutView, "app.html"},
-      entries: entries,
+      videos: videos,
       searchbar: true,
-      title: gettext("Recently created entries")
+      title: gettext("Recently created videos")
     )
   end
 

--- a/lib/sign_dict_web/templates/entry/latest.html.eex
+++ b/lib/sign_dict_web/templates/entry/latest.html.eex
@@ -2,31 +2,31 @@
   <div class="o-grid o-grid--wrap">
     <div class="o-grid__cell">
       <h1>
-        <%= gettext("Recently created entries") %>
+        <%= gettext("Recently created videos") %>
       </h1>
     </div>
   </div>
 </div>
 
 <div class="o-container o-container--medium">
-  <%= for entry <- @entries.entries do %>
+  <%= for video <- @videos.entries do %>
     <div class="o-grid o-grid--wrap">
-      <div class="o-grid__cell o-grid__cell--width-30">
-        <a href="<%= entry_path(@conn, :show, entry) %>">
-          <%= img_tag(entry.current_video.thumbnail_url, class: "o-image", alt: gettext("Thumbnail for Video")) %>
-        </a>
-      </div>
-      <div class="o-grid__cell">
-        <h2>
-          <%= link entry.text, to: entry_path(@conn, :show, entry), class: "so-search-result--link" %>
-        </h2>
+    <div class="o-grid__cell o-grid__cell--no-gutter o-grid__cell--width-30">
+      <a href="<%= entry_video_path(@conn, :show, video.entry, video) %>">
+      <%= img_tag(video.thumbnail_url, class: "o-image", alt: gettext("Thumbnail for Video")) %>
+      </a>
+    </div>
+    <div class="o-grid__cell">
+      <h2>
+      <%= link video.entry.text, to: entry_video_path(@conn, :show, video.entry, video), class: "so-search-result--link" %>
+      </h2>
 
-        <%= if entry.description && String.length(entry.description) > 0 do %>
-          <p><%= entry.description %></p>
-        <% end %>
-      </div>
+      <%= if String.length(video.entry.description) > 0 do %>
+      <p><%= video.entry.description %></p>
+      <% end %>
+    </div>
     </div>
   <% end %>
 
-  <%= pagination_links @entries %>
+  <%= pagination_links @videos %>
 </div>

--- a/lib/sign_dict_web/templates/shared/footer.html.eex
+++ b/lib/sign_dict_web/templates/shared/footer.html.eex
@@ -39,7 +39,7 @@
           <ul class="so-footer--links--list">
             <li><a href='https://github.com/signdict/website/wiki/API'>API</a></li>
             <li><a href='/entry'><%= gettext("All entries") %></a></li>
-            <li><a href='/latest'><%= gettext("New entries") %></a></li>
+            <li><a href='/latest'><%= gettext("New videos") %></a></li>
             <li><a href='http://docs.signdict.org'><%= gettext("Documentation") %></a></li>
           </ul>
         </div>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1251,11 +1251,11 @@ msgstr ""
 
 #, elixir-format
 #: lib/sign_dict_web/templates/shared/footer.html.eex:42
-msgid "New entries"
-msgstr "Neue Einträge"
+msgid "New videos"
+msgstr "Neue Videos"
 
 #, elixir-format
 #: lib/sign_dict_web/controllers/entry_controller.ex:42
 #: lib/sign_dict_web/templates/entry/latest.html.eex:5
-msgid "Recently created entries"
-msgstr "Zuletzt angelegte Einträge"
+msgid "Recently created videos"
+msgstr "Zuletzt angelegte Videos"

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1251,11 +1251,11 @@ msgstr ""
 
 #, elixir-format
 #: lib/sign_dict_web/templates/shared/footer.html.eex:42
-msgid "New entries"
+msgid "New videos"
 msgstr ""
 
 #, elixir-format
 #: lib/sign_dict_web/controllers/entry_controller.ex:42
 #: lib/sign_dict_web/templates/entry/latest.html.eex:5
-msgid "Recently created entries"
+msgid "Recently created videos"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1249,13 +1249,13 @@ msgstr ""
 msgid "Logo Wishlephant"
 msgstr ""
 
-#, elixir-format, fuzzy
+#, elixir-format
 #: lib/sign_dict_web/templates/shared/footer.html.eex:42
-msgid "New entries"
+msgid "New videos"
 msgstr ""
 
 #, elixir-format
 #: lib/sign_dict_web/controllers/entry_controller.ex:42
 #: lib/sign_dict_web/templates/entry/latest.html.eex:5
-msgid "Recently created entries"
+msgid "Recently created videos"
 msgstr ""


### PR DESCRIPTION
follow-up for #562

:created-at for entries gets updated more often than expected, so use video creation time instead.