### PR TITLE
Minor embed CSS fix

### DIFF
--- a/assets/css/objects/_embed.css
+++ b/assets/css/objects/_embed.css
@@ -26,6 +26,7 @@
 }
 
 .so-embed--player {
+  height: 100vh;
   position: absolute;
   left: 0;
   top: 0;
@@ -53,4 +54,3 @@
   height: auto;
   padding: 0.5em 1em;
 }
-


### PR DESCRIPTION
Just to avoid this behavior into embed videos:
![Captura de tela de 2019-10-12 19-08-00](https://user-images.githubusercontent.com/3226069/66708253-06312380-ed24-11e9-8bc3-8703cb475877.png)

With the fix, it's look something like this:
![Captura de tela de 2019-10-12 19-07-42](https://user-images.githubusercontent.com/3226069/66708247-f0236300-ed23-11e9-9435-f6e82fc70f65.png)
