### PR TITLE
Autoplay video entries

### DIFF
--- a/lib/sign_dict_web/templates/entry/show.html.eex
+++ b/lib/sign_dict_web/templates/entry/show.html.eex
@@ -6,7 +6,7 @@
 
 <div class="so-video">
   <div class="o-container o-container--medium">
-    <video class="so-video--player" playsinline controls loop src="<%= @video.video_url %>" poster="<%= @video.thumbnail_url %>"></video>
+    <video class="so-video--player" autoplay playsinline controls loop src="<%= @video.video_url %>" poster="<%= @video.thumbnail_url %>"></video>
   </div>
 </div>
 


### PR DESCRIPTION
When an entry is opened, it is currently necessary to click the play button of the video. Since watching the video is the prime purpose of the entry view it would make sense to start the video immediately.