### PR TITLE
Add autofocus on search input

### DIFF
--- a/lib/sign_dict_web/templates/page/index.html.eex
+++ b/lib/sign_dict_web/templates/page/index.html.eex
@@ -28,7 +28,7 @@
     <form action="/search" class='so-landing--search'>
       <div class="o-grid o-grid--wrap">
         <div class="o-grid__cell--width-80@medium o-grid__cell--width-100">
-          <input class="so-landing--search--input"  placeholder="<%= gettext("Search a word to see the GSL sign") %>" type="text" name="q" aria-label="<%= gettext("Enter word to search") %>"  data-controller="search"/>
+          <input class="so-landing--search--input"  placeholder="<%= gettext("Search a word to see the GSL sign") %>" type="text" name="q" aria-label="<%= gettext("Enter word to search") %>"  data-controller="search" autofocus/>
         </div>
         <div class="o-grid__cell so-landing--search--submit-cell">
           <input class="so-landing--search--submit" type="submit" value="<%= gettext("Search") %> &#8250;" />

--- a/lib/sign_dict_web/templates/page/sign2mint_index.html.eex
+++ b/lib/sign_dict_web/templates/page/sign2mint_index.html.eex
@@ -25,7 +25,7 @@
     <form action="/search" class='so-landing--search'>
       <div class="o-grid o-grid--wrap">
         <div class="o-grid__cell--width-80@medium o-grid__cell--width-100">
-          <input class="so-landing--search--input"  placeholder="<%= gettext("Search a word to see the GSL sign") %>" type="text" name="q" aria-label="<%= gettext("Enter word to search") %>"  data-controller="search"/>
+          <input class="so-landing--search--input"  placeholder="<%= gettext("Search a word to see the GSL sign") %>" type="text" name="q" aria-label="<%= gettext("Enter word to search") %>"  data-controller="search" autofocus/>
         </div>
         <div class="o-grid__cell so-landing--search--submit-cell">
           <input class="so-landing--search--submit" type="submit" value="<%= gettext("Search") %> &#8250;" />

--- a/lib/sign_dict_web/templates/shared/searchbar.html.eex
+++ b/lib/sign_dict_web/templates/shared/searchbar.html.eex
@@ -4,7 +4,7 @@
       <form action="/search">
         <div class="so-searchbar--container">
           <div class="so-searchbar--input">
-           <input class="so-searchbar--input--inner" type="text" name="q" aria-label="<%= gettext("Enter word to search") %>" placeholder="<%= gettext("Search a word to see the GSL sign") %>" value="<%= @conn.params["q"] %>" data-controller="search"/>
+           <input class="so-searchbar--input--inner" type="text" name="q" aria-label="<%= gettext("Enter word to search") %>" placeholder="<%= gettext("Search a word to see the GSL sign") %>" value="<%= @conn.params["q"] %>" data-controller="search" autofocus/>
           </div>
           <button class="so-searchbar--submit" type="submit">
             <i class="fa fa-search so-searchbar--icon" aria-hidden="true"></i>


### PR DESCRIPTION
This pull request adds the `autofocus` property to the search bar on the start page and to the shared search bar. This improves the user experience because it makes it possible to start typing directly when the site opens.