### PR TITLE
Automatically show English website for if browser is English 

### DIFF
--- a/lib/sign_dict_web/endpoint.ex
+++ b/lib/sign_dict_web/endpoint.ex
@@ -51,6 +51,7 @@ defmodule SignDictWeb.Endpoint do
     read_timeout: 60_000
   )
 
+  plug(Plug.Accepts)
   plug(Plug.MethodOverride)
   plug(Plug.Head)
 

--- a/lib/sign_dict_web/plugs/locale.ex
+++ b/lib/sign_dict_web/plugs/locale.ex
@@ -27,8 +27,15 @@ defmodule SignDictWeb.Plug.Locale do
   end
 
   defp get_user_locale(conn) do
-    if conn.assigns[:current_user] do
-      conn.assigns[:current_user].locale
+    accept_language = Plug.Conn.get_req_header(conn, "accept-language") |> Plug.Conn.get_accept_language()
+
+    case accept_language do
+      [locale | _rest] ->
+        locale
+      [] when conn.assigns[:current_user] ->
+        conn.assigns[:current_user].locale
+      _ ->
+        nil
     end
   end
 


### PR DESCRIPTION
Addressing [#228](https://github.com/signdict/website/issues/228).

Hi @bitboxer ,

This MR offers a proposed solution to the above linked ticket.

It connects to the plug Plug.Accepts to access accept-language from the HTTP request headers when fetching the page. Then, it updates `get_user_locale` to attempt to read from the headers. If this fails, it falls back to the existing behaviour for fetching from user definition.

Please do test this thoroughly as I had some issues when running SignDict locally. I don't believe they were related to the changes, but as the owner I expect you'll have better luck running the environment fully compared to me!

Please let me know if there's any issues/changes you'd like to see.

Best,
David